### PR TITLE
Feat : Swagger 테스트용 로그인 API 구현

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -27,7 +27,14 @@ SECRET_KEY = config("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = config("DEBUG", default=True, cast=bool)
 
-ALLOWED_HOSTS = []
+if DEBUG:
+    ALLOWED_HOSTS = []
+else:
+    ALLOWED_HOSTS = config(
+        "ALLOWED_HOSTS",
+        default="localhost,127.0.0.1",
+        cast=Csv(),
+    )
 
 
 # Application definition
@@ -124,7 +131,7 @@ ROOT_URLCONF = "config.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [BASE_DIR / "config" / "templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [

--- a/core/auth/urls.py
+++ b/core/auth/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
-from .views import SocialLoginView, LogoutView, TokenRefreshView
+from django.conf import settings
+from .views import SocialLoginView, LogoutView, TokenRefreshView, TestLoginView
 
 urlpatterns = [
     path(
@@ -18,3 +19,13 @@ urlpatterns = [
         name="token_refresh",
     ),
 ]
+
+# DEBUG 모드에서만 테스트 로그인 엔드포인트 추가
+if settings.DEBUG:
+    urlpatterns += [
+        path(
+            "auth/test-login/",
+            TestLoginView.as_view(),
+            name="test_login",
+        ),
+    ]

--- a/core/auth/views.py
+++ b/core/auth/views.py
@@ -1,4 +1,4 @@
-from django.db import IntegrityError
+from django.db import IntegrityError, OperationalError
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
@@ -250,15 +250,15 @@ def _get_test_login_description():
     base_description = "테스트용으로 특정 유저 ID로 로그인합니다. (DEBUG 모드에서만 사용 가능)"
     
     try:
-        users = User.objects.all().order_by('id')
+        # 필요한 필드만 조회하여 성능 향상
+        users = User.objects.only("id", "username").order_by('id')
         if users.exists():
-            user_list = []
-            for user in users:
-                user_list.append(f"{user.username} : {user.id}")
+            # 리스트 컴프리헨션으로 가독성 향상
+            user_list = [f"{user.username} : {user.id}" for user in users]
             user_info = "\n\n사용 가능한 유저\n\n" + "\n\n".join(user_list)
             return base_description + user_info
-    except Exception:
-        # 데이터베이스 접근 실패 시 기본 설명만 반환
+    except OperationalError:
+        # DB가 준비되지 않은 경우(예: 마이그레이션 전)를 대비하여 예외 처리
         pass
     
     return base_description

--- a/core/auth/views.py
+++ b/core/auth/views.py
@@ -89,38 +89,38 @@ class SocialLoginView(APIView):
 
         is_registered = not is_registration_required
 
-        response = Response(
-            {
-                "user": {
-                    "id": user.id,
-                    "provider": user.provider,
-                    "email": user.email,
-                    "username": user.username,
-                    "boj_username": user.boj_username,
-                    "profile_img_url": user.profile_img_url,
-                },
-                "is_registered": is_registered,
+        response_data = {
+            "user": {
+                "id": user.id,
+                "provider": user.provider,
+                "email": user.email,
+                "username": user.username,
+                "boj_username": user.boj_username,
+                "profile_img_url": user.profile_img_url,
             },
-            status=status.HTTP_200_OK,
-        )
+            "is_registered": is_registered,
+        }
+        serializer = SocialLoginResponseSerializer(data=response_data)
+        serializer.is_valid(raise_exception=True)
+        response = Response(serializer.validated_data, status=status.HTTP_200_OK)
 
         set_secure_cookie(
             response,
             "access_token",
             access_token,
-            max_age=ACCESS_TOKEN_LIFETIME,
+            max_age=int(ACCESS_TOKEN_LIFETIME.total_seconds()),
         )
         set_secure_cookie(
             response,
             "refresh_token",
             refresh_token,
-            max_age=REFRESH_TOKEN_LIFETIME,
+            max_age=int(REFRESH_TOKEN_LIFETIME.total_seconds()),
         )
         set_secure_cookie(
             response,
             "is_registered",
             str(is_registered).lower(),
-            max_age=REFRESH_TOKEN_LIFETIME,
+            max_age=int(REFRESH_TOKEN_LIFETIME.total_seconds()),
         )
 
         return response
@@ -228,19 +228,19 @@ class TokenRefreshView(APIView):
             response,
             "access_token",
             new_access_token,
-            max_age=ACCESS_TOKEN_LIFETIME,
+            max_age=int(ACCESS_TOKEN_LIFETIME.total_seconds()),
         )
         set_secure_cookie(
             response,
             "refresh_token",
             new_refresh_token,
-            max_age=REFRESH_TOKEN_LIFETIME,
+            max_age=int(REFRESH_TOKEN_LIFETIME.total_seconds()),
         )
         set_secure_cookie(
             response,
             "is_registered",
             str(is_registered).lower(),
-            max_age=REFRESH_TOKEN_LIFETIME,
+            max_age=int(REFRESH_TOKEN_LIFETIME.total_seconds()),
         )
         return response
 
@@ -334,47 +334,50 @@ class TestLoginView(APIView):
             )
 
         # 만료되지 않는 토큰 생성 (100년 후 만료)
+        test_token_lifetime = timedelta(days=36500)
+
         refresh = RefreshToken.for_user(user)
         access_token_obj = refresh.access_token
-        access_token_obj.set_exp(from_time=None, lifetime=timedelta(days=36500))
+        access_token_obj.set_exp(from_time=None, lifetime=test_token_lifetime)
 
         access_token = str(access_token_obj)
         refresh_token = str(refresh)
 
         is_registered = bool(user.boj_username)
 
-        response = Response(
-            {
-                "user": {
-                    "id": user.id,
-                    "provider": user.provider,
-                    "email": user.email,
-                    "username": user.username,
-                    "boj_username": user.boj_username,
-                    "profile_img_url": user.profile_img_url,
-                },
-                "is_registered": is_registered,
+        response_data = {
+            "user": {
+                "id": user.id,
+                "provider": user.provider,
+                "email": user.email,
+                "username": user.username,
+                "boj_username": user.boj_username,
+                "profile_img_url": user.profile_img_url,
             },
-            status=status.HTTP_200_OK,
-        )
+            "is_registered": is_registered,
+        }
+        serializer = SocialLoginResponseSerializer(data=response_data)
+        serializer.is_valid(raise_exception=True)
+        response = Response(serializer.validated_data, status=status.HTTP_200_OK)
 
+        # 테스트용 access token 쿠키는 토큰 만료 시간과 동일하게 설정
         set_secure_cookie(
             response,
             "access_token",
             access_token,
-            max_age=ACCESS_TOKEN_LIFETIME,
+            max_age=int(test_token_lifetime.total_seconds()),
         )
         set_secure_cookie(
             response,
             "refresh_token",
             refresh_token,
-            max_age=REFRESH_TOKEN_LIFETIME,
+            max_age=int(REFRESH_TOKEN_LIFETIME.total_seconds()),
         )
         set_secure_cookie(
             response,
             "is_registered",
             str(is_registered).lower(),
-            max_age=REFRESH_TOKEN_LIFETIME,
+            max_age=int(REFRESH_TOKEN_LIFETIME.total_seconds()),
         )
 
         return response

--- a/core/auth/views.py
+++ b/core/auth/views.py
@@ -7,7 +7,7 @@ from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.serializers import TokenRefreshSerializer
 from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.tokens import AccessToken
-from drf_spectacular.utils import extend_schema, OpenApiExample
+from drf_spectacular.utils import extend_schema, OpenApiExample, OpenApiParameter
 
 from core.models import User
 from core.utils.cookie import (
@@ -242,4 +242,139 @@ class TokenRefreshView(APIView):
             str(is_registered).lower(),
             max_age=REFRESH_TOKEN_LIFETIME,
         )
+        return response
+
+
+def _get_test_login_description():
+    """테스트 로그인 API 설명을 동적으로 생성"""
+    base_description = "테스트용으로 특정 유저 ID로 로그인합니다. (DEBUG 모드에서만 사용 가능)"
+    
+    try:
+        users = User.objects.all().order_by('id')
+        if users.exists():
+            user_list = []
+            for user in users:
+                user_list.append(f"{user.username} : {user.id}")
+            user_info = "\n\n사용 가능한 유저\n\n" + "\n\n".join(user_list)
+            return base_description + user_info
+    except Exception:
+        # 데이터베이스 접근 실패 시 기본 설명만 반환
+        pass
+    
+    return base_description
+
+
+@extend_schema(tags=["auth"])
+class TestLoginView(APIView):
+    """테스트용 로그인 API (DEBUG 모드에서만 사용 가능)"""
+
+    @extend_schema(
+        summary="테스트 로그인",
+        description=_get_test_login_description(),
+        request=None,
+        responses={
+            200: SocialLoginResponseSerializer,
+            400: ErrorEnvelopeSerializer,
+            403: ErrorEnvelopeSerializer,
+        },
+        parameters=[
+            OpenApiParameter(
+                name="user_id",
+                type=int,
+                location=OpenApiParameter.QUERY,
+                required=True,
+                description="로그인할 유저 ID",
+            )
+        ],
+    )
+    def post(self, request):
+        from django.conf import settings
+        from datetime import timedelta
+
+        # DEBUG 모드에서만 사용 가능
+        if not settings.DEBUG:
+            return Response(
+                {
+                    "error_code": "FORBIDDEN",
+                    "message": "테스트 로그인은 DEBUG 모드에서만 사용할 수 있습니다.",
+                },
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        user_id = request.query_params.get("user_id")
+        if not user_id:
+            return Response(
+                {
+                    "error_code": "MISSING_USER_ID",
+                    "message": "user_id 파라미터가 필요합니다.",
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            user_id = int(user_id)
+        except ValueError:
+            return Response(
+                {
+                    "error_code": "INVALID_USER_ID",
+                    "message": "유효하지 않은 user_id입니다.",
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            user = User.objects.get(id=user_id)
+        except User.DoesNotExist:
+            return Response(
+                {
+                    "error_code": "USER_NOT_FOUND",
+                    "message": f"유저 ID {user_id}를 찾을 수 없습니다.",
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # 만료되지 않는 토큰 생성 (100년 후 만료)
+        refresh = RefreshToken.for_user(user)
+        access_token_obj = refresh.access_token
+        access_token_obj.set_exp(from_time=None, lifetime=timedelta(days=36500))
+
+        access_token = str(access_token_obj)
+        refresh_token = str(refresh)
+
+        is_registered = bool(user.boj_username)
+
+        response = Response(
+            {
+                "user": {
+                    "id": user.id,
+                    "provider": user.provider,
+                    "email": user.email,
+                    "username": user.username,
+                    "boj_username": user.boj_username,
+                    "profile_img_url": user.profile_img_url,
+                },
+                "is_registered": is_registered,
+            },
+            status=status.HTTP_200_OK,
+        )
+
+        set_secure_cookie(
+            response,
+            "access_token",
+            access_token,
+            max_age=ACCESS_TOKEN_LIFETIME,
+        )
+        set_secure_cookie(
+            response,
+            "refresh_token",
+            refresh_token,
+            max_age=REFRESH_TOKEN_LIFETIME,
+        )
+        set_secure_cookie(
+            response,
+            "is_registered",
+            str(is_registered).lower(),
+            max_age=REFRESH_TOKEN_LIFETIME,
+        )
+
         return response


### PR DESCRIPTION
### 🚀 개요 (Overview)

<!---
이 PR의 목적과 배경을 간략하게 설명해주세요.

예시)
[ resolves #1 ]

- 로그인 기능 추가
- 특정 버그 수정
-->

[ resolves #21 ]

- Swagger UI에서 테스트용 로그인 기능 구현 및 개선
- 테스트 환경에서 편리하게 사용할 수 있는 만료되지 않는 토큰 발급 기능 추가
- Swagger UI에서 Bearer 토큰 인증 지원으로 API 테스트 편의성 향상

<br>

### 🔎 변경사항 (Changes)

<!---
이번 PR에서 변경된 주요 내용을 목록으로 작성해주세요.

예시)
- `/pages/login.tsx` 페이지 추가
- 로그인 API 연동을 위한 `/lib/auth.ts` 추가
- 로그인 버튼 컴포넌트 스타일 수정
-->

- `core/auth/authentication.py` - `CustomJWTAuthentication` 개선: 쿠키와 Authorization 헤더 모두에서 토큰 읽기 지원
- `core/auth/views.py` - `TestLoginView` 추가: DEBUG 모드에서만 사용 가능한 테스트 로그인 API
- `core/auth/urls.py` - DEBUG 모드일 때만 test-login 엔드포인트 등록하도록 조건부 처리
- `core/auth/views.py` - test-login API description에 모든 유저의 `username : user_id` 목록 동적 표시 기능 추가

<br>

### 📝 참고사항 (Etc)

<!--- 리뷰어가 특별히 신경 써서 봐야 할 부분이나, 기타 참고해야 할 사항을 작성해주세요. (특정 라이브러리 사용 이유, 테스트 방법 등) -->

1. Swagger UI에서 테스트:
   - Swagger UI: `http://localhost:8000/api/docs/`
   - Authorization 헤더에 Bearer 토큰 입력 또는 쿠키로 자동 인증
   - `POST /api/auth/test-login/?user_id={user_id}` 엔드포인트로 테스트 로그인

2. DEBUG 모드 확인:
   - `.env` 파일에 `DEBUG=True` 설정 필요
   - DEBUG 모드가 아니면 test-login 엔드포인트가 Swagger UI에 표시되지 않음

**테스트 시나리오:**
- [x] DEBUG=True일 때 test-login API가 Swagger UI에 표시되는지 확인
- [x] DEBUG=False일 때 test-login API가 Swagger UI에서 숨겨지는지 확인
- [x] Swagger UI에서 Bearer 토큰으로 인증 가능한지 확인
- [x] test-login API description에 유저 목록이 표시되는지 확인
- [x] 모든 유저 ID로 테스트 로그인 가능한지 확인

<br>

### 📸 스크린샷 (Screenshots)

<!--- 
변경된 UI가 있다면, 스크린샷을 첨부해주세요.

예시)
< 스크린샷 이름>
스크린샷
-->

<img width="1429" height="53" alt="image" src="https://github.com/user-attachments/assets/f848e505-f057-44d5-8bc6-be2b71ddf813" />

