### PR TITLE
Feat: 스터디 멤버 관련 API 구현

### DIFF
--- a/core/member/serializers.py
+++ b/core/member/serializers.py
@@ -1,0 +1,27 @@
+from rest_framework import serializers
+
+from core.models import StudyMember
+
+
+class StudyMemberListSerializer(serializers.ModelSerializer):
+    """스터디 멤버 목록 Serializer"""
+
+    id = serializers.IntegerField(source="user.id", read_only=True)
+    username = serializers.CharField(source="user.username", read_only=True)
+    email = serializers.EmailField(source="user.email", read_only=True)
+    boj_username = serializers.CharField(
+        source="user.boj_username", read_only=True, allow_null=True
+    )
+    role = serializers.CharField(read_only=True)
+    joined_at = serializers.DateTimeField(read_only=True)
+
+    class Meta:
+        model = StudyMember
+        fields = [
+            "id",
+            "username",
+            "email",
+            "boj_username",
+            "role",
+            "joined_at",
+        ]

--- a/core/member/services.py
+++ b/core/member/services.py
@@ -1,0 +1,51 @@
+from django.db import transaction
+
+from core.models import StudyMember, StudyRole
+
+
+class StudyMemberService:
+    """스터디 멤버 관련 비즈니스 로직 서비스"""
+
+    def transfer_ownership(self, study, current_owner, new_owner_id):
+        """
+        스터디장 권한을 다른 멤버에게 위임합니다.
+
+        Args:
+            study: 스터디 인스턴스
+            current_owner: 현재 스터디장 (User 인스턴스)
+            new_owner_id: 새 스터디장이 될 멤버의 user_id
+
+        Returns:
+            None
+
+        Raises:
+            ValueError: 새 스터디장이 될 멤버가 없거나, 자기 자신에게 위임하려는 경우
+        """
+        # 새 스터디장이 될 멤버 조회
+        new_owner_membership = StudyMember.objects.filter(
+            study=study, user_id=new_owner_id
+        ).first()
+
+        if not new_owner_membership:
+            raise ValueError("MEMBER_NOT_FOUND")
+
+        # 자기 자신에게 위임 불가
+        if new_owner_membership.user_id == current_owner.id:
+            raise ValueError("CANNOT_TRANSFER_TO_SELF")
+
+        # 현재 스터디장의 멤버십 조회
+        current_owner_membership = StudyMember.objects.get(
+            study=study, user=current_owner
+        )
+
+        # 스터디장 권한 위임
+        with transaction.atomic():
+            current_owner_membership.role = StudyRole.MEMBER
+            current_owner_membership.save()
+
+            new_owner_membership.role = StudyRole.OWNER
+            new_owner_membership.save()
+
+            # Study.owner 업데이트
+            study.owner = new_owner_membership.user
+            study.save()

--- a/core/member/urls.py
+++ b/core/member/urls.py
@@ -1,0 +1,24 @@
+from django.urls import path
+from .views import (
+    StudyMemberListView,
+    StudyMemberKickView,
+    StudyOwnerTransferView,
+)
+
+urlpatterns = [
+    path(
+        "studies/<int:study_id>/members/",
+        StudyMemberListView.as_view(),
+        name="study_member_list",
+    ),
+    path(
+        "studies/<int:study_id>/members/<int:member_id>/",
+        StudyMemberKickView.as_view(),
+        name="study_member_kick",
+    ),
+    path(
+        "studies/<int:study_id>/members/<int:member_id>/owner/",
+        StudyOwnerTransferView.as_view(),
+        name="study_owner_transfer",
+    ),
+]

--- a/core/member/views.py
+++ b/core/member/views.py
@@ -1,0 +1,133 @@
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from django.shortcuts import get_object_or_404
+from drf_spectacular.utils import extend_schema
+
+from core.models import Study, StudyMember, StudyRole
+from core.common.serializers import ErrorEnvelopeSerializer
+from core.study.permissions import IsStudyOwner, IsStudyMember
+from .serializers import StudyMemberListSerializer
+from .services import StudyMemberService
+
+
+@extend_schema(tags=["members"])
+class StudyMemberListView(APIView):
+    """스터디 멤버 목록 조회 API"""
+
+    permission_classes = [IsAuthenticated, IsStudyMember]
+
+    @extend_schema(
+        summary="스터디 멤버 목록 조회",
+        description="스터디에 가입한 멤버 목록을 조회합니다. 스터디 멤버만 조회 가능합니다.",
+        responses={200: StudyMemberListSerializer(many=True)},
+    )
+    def get(self, request, study_id):
+        study = get_object_or_404(Study, id=study_id)
+        self.check_object_permissions(request, study)
+
+        members = (
+            StudyMember.objects.filter(study=study)
+            .select_related("user")
+            .order_by("joined_at")
+        )
+
+        serializer = StudyMemberListSerializer(members, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+@extend_schema(tags=["members"])
+class StudyMemberKickView(APIView):
+    """스터디 멤버 강제 퇴출 API"""
+
+    permission_classes = [IsAuthenticated, IsStudyOwner]
+
+    @extend_schema(
+        summary="스터디 멤버 강제 퇴출",
+        description="스터디장이 특정 멤버를 스터디에서 강제 퇴출시킵니다. 스터디장 자신은 퇴출할 수 없습니다.",
+        responses={
+            204: None,
+            400: ErrorEnvelopeSerializer,
+            404: ErrorEnvelopeSerializer,
+        },
+    )
+    def delete(self, request, study_id, member_id):
+        study = get_object_or_404(Study, id=study_id)
+        self.check_object_permissions(request, study)
+
+        # 퇴출 대상 멤버 조회
+        membership = StudyMember.objects.filter(
+            study_id=study_id, user_id=member_id
+        ).first()
+
+        if not membership:
+            return Response(
+                {
+                    "error_code": "MEMBER_NOT_FOUND",
+                    "message": "해당 멤버를 찾을 수 없습니다.",
+                },
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        # 스터디장은 퇴출 불가
+        if membership.role == StudyRole.OWNER:
+            return Response(
+                {
+                    "error_code": "CANNOT_KICK_OWNER",
+                    "message": "스터디장은 퇴출할 수 없습니다.",
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        membership.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+@extend_schema(tags=["members"])
+class StudyOwnerTransferView(APIView):
+    """스터디장 위임 API"""
+
+    permission_classes = [IsAuthenticated, IsStudyOwner]
+    service_class = StudyMemberService
+
+    @extend_schema(
+        summary="스터디장 위임",
+        description="현재 스터디장이 다른 멤버에게 스터디장 권한을 위임합니다.",
+        responses={
+            204: None,
+            400: ErrorEnvelopeSerializer,
+            404: ErrorEnvelopeSerializer,
+        },
+    )
+    def patch(self, request, study_id, member_id):
+        study = get_object_or_404(Study, id=study_id)
+        self.check_object_permissions(request, study)
+
+        try:
+            service = self.service_class()
+            service.transfer_ownership(
+                study=study,
+                current_owner=request.user,
+                new_owner_id=member_id,
+            )
+        except ValueError as e:
+            error_code = str(e)
+            if error_code == "MEMBER_NOT_FOUND":
+                return Response(
+                    {
+                        "error_code": "MEMBER_NOT_FOUND",
+                        "message": "해당 멤버를 찾을 수 없습니다.",
+                    },
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+            elif error_code == "CANNOT_TRANSFER_TO_SELF":
+                return Response(
+                    {
+                        "error_code": "CANNOT_TRANSFER_TO_SELF",
+                        "message": "자기 자신에게는 위임할 수 없습니다.",
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/core/study/serializers.py
+++ b/core/study/serializers.py
@@ -128,27 +128,3 @@ class StudyCreateErrorSerializer(serializers.Serializer):
 
 class StudyJoinResponseSerializer(serializers.Serializer):
     id = serializers.IntegerField()
-
-
-class StudyMemberListSerializer(serializers.ModelSerializer):
-    """스터디 멤버 목록 Serializer"""
-
-    id = serializers.IntegerField(source="user.id", read_only=True)
-    username = serializers.CharField(source="user.username", read_only=True)
-    email = serializers.EmailField(source="user.email", read_only=True)
-    boj_username = serializers.CharField(
-        source="user.boj_username", read_only=True, allow_null=True
-    )
-    role = serializers.CharField(read_only=True)
-    joined_at = serializers.DateTimeField(read_only=True)
-
-    class Meta:
-        model = StudyMember
-        fields = [
-            "id",
-            "username",
-            "email",
-            "boj_username",
-            "role",
-            "joined_at",
-        ]

--- a/core/study/serializers.py
+++ b/core/study/serializers.py
@@ -128,3 +128,27 @@ class StudyCreateErrorSerializer(serializers.Serializer):
 
 class StudyJoinResponseSerializer(serializers.Serializer):
     id = serializers.IntegerField()
+
+
+class StudyMemberListSerializer(serializers.ModelSerializer):
+    """스터디 멤버 목록 Serializer"""
+
+    id = serializers.IntegerField(source="user.id", read_only=True)
+    username = serializers.CharField(source="user.username", read_only=True)
+    email = serializers.EmailField(source="user.email", read_only=True)
+    boj_username = serializers.CharField(
+        source="user.boj_username", read_only=True, allow_null=True
+    )
+    role = serializers.CharField(read_only=True)
+    joined_at = serializers.DateTimeField(read_only=True)
+
+    class Meta:
+        model = StudyMember
+        fields = [
+            "id",
+            "username",
+            "email",
+            "boj_username",
+            "role",
+            "joined_at",
+        ]

--- a/core/study/services.py
+++ b/core/study/services.py
@@ -30,10 +30,6 @@ class StudyService:
 
         return study
 
-
-class StudyMemberService:
-    """스터디 멤버 관련 비즈니스 로직 서비스"""
-
     def join_study(self, user, invite_code):
         """
         초대 코드를 사용하여 스터디에 가입합니다.

--- a/core/study/urls.py
+++ b/core/study/urls.py
@@ -5,9 +5,6 @@ from .views import (
     StudyJoinView,
     StudyLeaveView,
     StudyListView,
-    StudyMemberListView,
-    StudyMemberKickView,
-    StudyOwnerTransferView,
 )
 
 urlpatterns = [
@@ -35,20 +32,5 @@ urlpatterns = [
         "studies/<int:study_id>/leave/",
         StudyLeaveView.as_view(),
         name="study_leave",
-    ),
-    path(
-        "studies/<int:study_id>/members/",
-        StudyMemberListView.as_view(),
-        name="study_member_list",
-    ),
-    path(
-        "studies/<int:study_id>/members/<int:member_id>/",
-        StudyMemberKickView.as_view(),
-        name="study_member_kick",
-    ),
-    path(
-        "studies/<int:study_id>/members/<int:member_id>/owner/",
-        StudyOwnerTransferView.as_view(),
-        name="study_owner_transfer",
     ),
 ]

--- a/core/study/urls.py
+++ b/core/study/urls.py
@@ -5,6 +5,9 @@ from .views import (
     StudyJoinView,
     StudyLeaveView,
     StudyListView,
+    StudyMemberListView,
+    StudyMemberKickView,
+    StudyOwnerTransferView,
 )
 
 urlpatterns = [
@@ -32,5 +35,20 @@ urlpatterns = [
         "studies/<int:study_id>/leave/",
         StudyLeaveView.as_view(),
         name="study_leave",
+    ),
+    path(
+        "studies/<int:study_id>/members/",
+        StudyMemberListView.as_view(),
+        name="study_member_list",
+    ),
+    path(
+        "studies/<int:study_id>/members/<int:member_id>/",
+        StudyMemberKickView.as_view(),
+        name="study_member_kick",
+    ),
+    path(
+        "studies/<int:study_id>/members/<int:member_id>/owner/",
+        StudyOwnerTransferView.as_view(),
+        name="study_owner_transfer",
     ),
 ]

--- a/core/study/views.py
+++ b/core/study/views.py
@@ -15,6 +15,7 @@ from .serializers import (
     StudyJoinSerializer,
     StudyJoinResponseSerializer,
     StudyListSerializer,
+    StudyMemberListSerializer,
 )
 from core.common.serializers import ErrorEnvelopeSerializer
 from .services import (
@@ -220,3 +221,140 @@ class StudyListView(APIView):
 
         serializer = StudyListSerializer(study_memberships, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+@extend_schema(tags=["studies"])
+class StudyMemberListView(APIView):
+    """스터디 멤버 목록 조회 API"""
+
+    permission_classes = [IsAuthenticated, IsStudyMember]
+
+    @extend_schema(
+        summary="스터디 멤버 목록 조회",
+        description="스터디에 가입한 멤버 목록을 조회합니다. 스터디 멤버만 조회 가능합니다.",
+        responses={200: StudyMemberListSerializer(many=True)},
+    )
+    def get(self, request, study_id):
+        study = get_object_or_404(Study, id=study_id)
+        self.check_object_permissions(request, study)
+
+        members = (
+            StudyMember.objects.filter(study=study)
+            .select_related("user")
+            .order_by("joined_at")
+        )
+
+        serializer = StudyMemberListSerializer(members, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+@extend_schema(tags=["studies"])
+class StudyMemberKickView(APIView):
+    """스터디 멤버 강제 퇴출 API"""
+
+    permission_classes = [IsAuthenticated, IsStudyOwner]
+
+    @extend_schema(
+        summary="스터디 멤버 강제 퇴출",
+        description="스터디장이 특정 멤버를 스터디에서 강제 퇴출시킵니다. 스터디장 자신은 퇴출할 수 없습니다.",
+        responses={
+            204: None,
+            400: ErrorEnvelopeSerializer,
+            404: ErrorEnvelopeSerializer,
+        },
+    )
+    def delete(self, request, study_id, member_id):
+        study = get_object_or_404(Study, id=study_id)
+        self.check_object_permissions(request, study)
+
+        # 퇴출 대상 멤버 조회
+        membership = StudyMember.objects.filter(
+            study_id=study_id, user_id=member_id
+        ).first()
+
+        if not membership:
+            return Response(
+                {
+                    "error_code": "MEMBER_NOT_FOUND",
+                    "message": "해당 멤버를 찾을 수 없습니다.",
+                },
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        # 스터디장은 퇴출 불가
+        if membership.role == StudyRole.OWNER:
+            return Response(
+                {
+                    "error_code": "CANNOT_KICK_OWNER",
+                    "message": "스터디장은 퇴출할 수 없습니다.",
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        membership.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+@extend_schema(tags=["studies"])
+class StudyOwnerTransferView(APIView):
+    """스터디장 위임 API"""
+
+    permission_classes = [IsAuthenticated, IsStudyOwner]
+
+    @extend_schema(
+        summary="스터디장 위임",
+        description="현재 스터디장이 다른 멤버에게 스터디장 권한을 위임합니다.",
+        responses={
+            200: None,
+            400: ErrorEnvelopeSerializer,
+            404: ErrorEnvelopeSerializer,
+        },
+    )
+    def patch(self, request, study_id, member_id):
+        study = get_object_or_404(Study, id=study_id)
+        self.check_object_permissions(request, study)
+
+        # 새 스터디장이 될 멤버 조회
+        new_owner_membership = StudyMember.objects.filter(
+            study_id=study_id, user_id=member_id
+        ).first()
+
+        if not new_owner_membership:
+            return Response(
+                {
+                    "error_code": "MEMBER_NOT_FOUND",
+                    "message": "해당 멤버를 찾을 수 없습니다.",
+                },
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        # 자기 자신에게 위임 불가
+        if new_owner_membership.user_id == request.user.id:
+            return Response(
+                {
+                    "error_code": "CANNOT_TRANSFER_TO_SELF",
+                    "message": "자기 자신에게는 위임할 수 없습니다.",
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # 현재 스터디장의 멤버십 조회
+        current_owner_membership = StudyMember.objects.get(
+            study_id=study_id, user=request.user
+        )
+
+        # 역할 교체
+        current_owner_membership.role = StudyRole.MEMBER
+        current_owner_membership.save()
+
+        new_owner_membership.role = StudyRole.OWNER
+        new_owner_membership.save()
+
+        # Study.owner 업데이트
+        study.owner = new_owner_membership.user
+        study.save()
+
+        return Response(
+            {"message": "스터디장이 성공적으로 위임되었습니다."},
+            status=status.HTTP_200_OK,
+        )

--- a/core/study/views.py
+++ b/core/study/views.py
@@ -15,13 +15,9 @@ from .serializers import (
     StudyJoinSerializer,
     StudyJoinResponseSerializer,
     StudyListSerializer,
-    StudyMemberListSerializer,
 )
 from core.common.serializers import ErrorEnvelopeSerializer
-from .services import (
-    StudyService,
-    StudyMemberService,
-)
+from .services import StudyService
 from .permissions import IsStudyOwner, IsStudyMember
 
 
@@ -129,7 +125,7 @@ class StudyJoinView(APIView):
     """스터디 가입 API"""
 
     permission_classes = [IsAuthenticated]
-    service_class = StudyMemberService
+    service_class = StudyService
 
     @extend_schema(
         summary="스터디 가입",
@@ -221,140 +217,3 @@ class StudyListView(APIView):
 
         serializer = StudyListSerializer(study_memberships, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
-
-
-@extend_schema(tags=["studies"])
-class StudyMemberListView(APIView):
-    """스터디 멤버 목록 조회 API"""
-
-    permission_classes = [IsAuthenticated, IsStudyMember]
-
-    @extend_schema(
-        summary="스터디 멤버 목록 조회",
-        description="스터디에 가입한 멤버 목록을 조회합니다. 스터디 멤버만 조회 가능합니다.",
-        responses={200: StudyMemberListSerializer(many=True)},
-    )
-    def get(self, request, study_id):
-        study = get_object_or_404(Study, id=study_id)
-        self.check_object_permissions(request, study)
-
-        members = (
-            StudyMember.objects.filter(study=study)
-            .select_related("user")
-            .order_by("joined_at")
-        )
-
-        serializer = StudyMemberListSerializer(members, many=True)
-        return Response(serializer.data, status=status.HTTP_200_OK)
-
-
-@extend_schema(tags=["studies"])
-class StudyMemberKickView(APIView):
-    """스터디 멤버 강제 퇴출 API"""
-
-    permission_classes = [IsAuthenticated, IsStudyOwner]
-
-    @extend_schema(
-        summary="스터디 멤버 강제 퇴출",
-        description="스터디장이 특정 멤버를 스터디에서 강제 퇴출시킵니다. 스터디장 자신은 퇴출할 수 없습니다.",
-        responses={
-            204: None,
-            400: ErrorEnvelopeSerializer,
-            404: ErrorEnvelopeSerializer,
-        },
-    )
-    def delete(self, request, study_id, member_id):
-        study = get_object_or_404(Study, id=study_id)
-        self.check_object_permissions(request, study)
-
-        # 퇴출 대상 멤버 조회
-        membership = StudyMember.objects.filter(
-            study_id=study_id, user_id=member_id
-        ).first()
-
-        if not membership:
-            return Response(
-                {
-                    "error_code": "MEMBER_NOT_FOUND",
-                    "message": "해당 멤버를 찾을 수 없습니다.",
-                },
-                status=status.HTTP_404_NOT_FOUND,
-            )
-
-        # 스터디장은 퇴출 불가
-        if membership.role == StudyRole.OWNER:
-            return Response(
-                {
-                    "error_code": "CANNOT_KICK_OWNER",
-                    "message": "스터디장은 퇴출할 수 없습니다.",
-                },
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        membership.delete()
-        return Response(status=status.HTTP_204_NO_CONTENT)
-
-
-@extend_schema(tags=["studies"])
-class StudyOwnerTransferView(APIView):
-    """스터디장 위임 API"""
-
-    permission_classes = [IsAuthenticated, IsStudyOwner]
-
-    @extend_schema(
-        summary="스터디장 위임",
-        description="현재 스터디장이 다른 멤버에게 스터디장 권한을 위임합니다.",
-        responses={
-            200: None,
-            400: ErrorEnvelopeSerializer,
-            404: ErrorEnvelopeSerializer,
-        },
-    )
-    def patch(self, request, study_id, member_id):
-        study = get_object_or_404(Study, id=study_id)
-        self.check_object_permissions(request, study)
-
-        # 새 스터디장이 될 멤버 조회
-        new_owner_membership = StudyMember.objects.filter(
-            study_id=study_id, user_id=member_id
-        ).first()
-
-        if not new_owner_membership:
-            return Response(
-                {
-                    "error_code": "MEMBER_NOT_FOUND",
-                    "message": "해당 멤버를 찾을 수 없습니다.",
-                },
-                status=status.HTTP_404_NOT_FOUND,
-            )
-
-        # 자기 자신에게 위임 불가
-        if new_owner_membership.user_id == request.user.id:
-            return Response(
-                {
-                    "error_code": "CANNOT_TRANSFER_TO_SELF",
-                    "message": "자기 자신에게는 위임할 수 없습니다.",
-                },
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        # 현재 스터디장의 멤버십 조회
-        current_owner_membership = StudyMember.objects.get(
-            study_id=study_id, user=request.user
-        )
-
-        # 역할 교체
-        current_owner_membership.role = StudyRole.MEMBER
-        current_owner_membership.save()
-
-        new_owner_membership.role = StudyRole.OWNER
-        new_owner_membership.save()
-
-        # Study.owner 업데이트
-        study.owner = new_owner_membership.user
-        study.save()
-
-        return Response(
-            {"message": "스터디장이 성공적으로 위임되었습니다."},
-            status=status.HTTP_200_OK,
-        )

--- a/core/urls.py
+++ b/core/urls.py
@@ -4,6 +4,7 @@ urlpatterns = [
     path("", include("core.auth.urls")),
     path("", include("core.user.urls")),
     path("", include("core.study.urls")),
+    path("", include("core.member.urls")),
     path("", include("core.assignments.urls")),
     path("", include("core.note.urls")),
     path("", include("core.problem_solving_status.urls")),


### PR DESCRIPTION
- 스터디 멤버 목록 조회, 추방, 스터디장 위임 기능 추가

### 🚀 개요 (Overview)

<!---
이 PR의 목적과 배경을 간략하게 설명해주세요.

예시)
[ resolves #1 ]

- 로그인 기능 추가
- 특정 버그 수정
-->

[ resolves #27 ]

- 스터디 멤버 목록 조회, 멤버 추방, 스터디장 권한 위임 API 구현

<br>

### 🔎 변경사항 (Changes)

<!---
이번 PR에서 변경된 주요 내용을 목록으로 작성해주세요.

예시)
- `/pages/login.tsx` 페이지 추가
- 로그인 API 연동을 위한 `/lib/auth.ts` 추가
- 로그인 버튼 컴포넌트 스타일 수정
-->

- 스터디 멤버 관련 API 추가
  - `api/studies/{study_id}/members/` `GET` -> 스터디 멤버 목록 조회
  - `api/studies/{study_id}/members/{member_id}/` `DELETE` -> 스터디 멤버 추방 
  - `api/studies/{study_id}/members/{member_id}/owner` `PATCH` -> 스터디장 권한 위임

<br>
