### PR TITLE
Feat: 회원 탈퇴 API 추가

### DIFF
--- a/core/auth/authentication.py
+++ b/core/auth/authentication.py
@@ -2,10 +2,12 @@ from rest_framework_simplejwt.authentication import JWTAuthentication
 from rest_framework.exceptions import AuthenticationFailed
 from drf_spectacular.extensions import OpenApiAuthenticationExtension
 
+from core.utils.cookie import ACCESS_TOKEN_COOKIE
+
 
 class CustomJWTAuthentication(JWTAuthentication):
     def authenticate(self, request):
-        raw_token = request.COOKIES.get("access_token")
+        raw_token = request.COOKIES.get(ACCESS_TOKEN_COOKIE)
 
         if raw_token is None:
             return None
@@ -26,5 +28,5 @@ class CustomJWTAuthenticationExtension(OpenApiAuthenticationExtension):
         return {
             "type": "apiKey",
             "in": "cookie",
-            "name": "access_token",
+            "name": ACCESS_TOKEN_COOKIE,
         }

--- a/core/auth/views.py
+++ b/core/auth/views.py
@@ -14,6 +14,9 @@ from core.utils.cookie import (
     set_secure_cookie,
     ACCESS_TOKEN_LIFETIME,
     REFRESH_TOKEN_LIFETIME,
+    ACCESS_TOKEN_COOKIE,
+    REFRESH_TOKEN_COOKIE,
+    IS_REGISTERED_COOKIE,
 )
 from core.auth.services import SocialLoginService
 from .serializers import (
@@ -106,19 +109,19 @@ class SocialLoginView(APIView):
 
         set_secure_cookie(
             response,
-            "access_token",
+            ACCESS_TOKEN_COOKIE,
             access_token,
             max_age=int(ACCESS_TOKEN_LIFETIME.total_seconds()),
         )
         set_secure_cookie(
             response,
-            "refresh_token",
+            REFRESH_TOKEN_COOKIE,
             refresh_token,
             max_age=int(REFRESH_TOKEN_LIFETIME.total_seconds()),
         )
         set_secure_cookie(
             response,
-            "is_registered",
+            IS_REGISTERED_COOKIE,
             str(is_registered).lower(),
             max_age=int(REFRESH_TOKEN_LIFETIME.total_seconds()),
         )
@@ -142,7 +145,7 @@ class LogoutView(APIView):
         },
     )
     def post(self, request):
-        refresh_token = request.COOKIES.get("refresh_token")
+        refresh_token = request.COOKIES.get(REFRESH_TOKEN_COOKIE)
 
         if refresh_token:
             try:
@@ -159,9 +162,9 @@ class LogoutView(APIView):
 
         response = Response(status=status.HTTP_204_NO_CONTENT)
 
-        response.delete_cookie("access_token")
-        response.delete_cookie("refresh_token")
-        response.delete_cookie("is_registered")
+        response.delete_cookie(ACCESS_TOKEN_COOKIE)
+        response.delete_cookie(REFRESH_TOKEN_COOKIE)
+        response.delete_cookie(IS_REGISTERED_COOKIE)
 
         return response
 
@@ -181,7 +184,7 @@ class TokenRefreshView(APIView):
         },
     )
     def post(self, request):
-        refresh_token = request.COOKIES.get("refresh_token")
+        refresh_token = request.COOKIES.get(REFRESH_TOKEN_COOKIE)
 
         if not refresh_token:
             return Response(
@@ -226,19 +229,19 @@ class TokenRefreshView(APIView):
 
         set_secure_cookie(
             response,
-            "access_token",
+            ACCESS_TOKEN_COOKIE,
             new_access_token,
             max_age=int(ACCESS_TOKEN_LIFETIME.total_seconds()),
         )
         set_secure_cookie(
             response,
-            "refresh_token",
+            REFRESH_TOKEN_COOKIE,
             new_refresh_token,
             max_age=int(REFRESH_TOKEN_LIFETIME.total_seconds()),
         )
         set_secure_cookie(
             response,
-            "is_registered",
+            IS_REGISTERED_COOKIE,
             str(is_registered).lower(),
             max_age=int(REFRESH_TOKEN_LIFETIME.total_seconds()),
         )
@@ -365,19 +368,19 @@ class TestLoginView(APIView):
         # 테스트용 access token 쿠키는 토큰 만료 시간과 동일하게 설정
         set_secure_cookie(
             response,
-            "access_token",
+            ACCESS_TOKEN_COOKIE,
             access_token,
             max_age=int(test_token_lifetime.total_seconds()),
         )
         set_secure_cookie(
             response,
-            "refresh_token",
+            REFRESH_TOKEN_COOKIE,
             refresh_token,
             max_age=int(REFRESH_TOKEN_LIFETIME.total_seconds()),
         )
         set_secure_cookie(
             response,
-            "is_registered",
+            IS_REGISTERED_COOKIE,
             str(is_registered).lower(),
             max_age=int(REFRESH_TOKEN_LIFETIME.total_seconds()),
         )

--- a/core/user/services.py
+++ b/core/user/services.py
@@ -1,0 +1,36 @@
+from core.models import Study
+
+
+class UserService:
+    """사용자 관련 비즈니스 로직 서비스"""
+
+    class StudyOwnerCannotDeleteError(Exception):
+        """스터디장인 경우 탈퇴 불가 예외"""
+
+        def __init__(self, study_names: list[str]):
+            self.study_names = study_names
+            super().__init__("스터디장인 스터디가 있어 탈퇴할 수 없습니다.")
+
+    def delete_user(self, user):
+        """
+        사용자를 삭제합니다.
+
+        스터디장인 경우 먼저 스터디장 권한을 위임해야 합니다.
+
+        Args:
+            user: 삭제할 사용자 인스턴스
+
+        Returns:
+            None
+
+        Raises:
+            StudyOwnerCannotDeleteError: 스터디장인 경우
+        """
+        # 스터디 오너인 경우 탈퇴 불가
+        owned_studies = Study.objects.filter(owner=user)
+        if owned_studies.exists():
+            study_names = list(owned_studies.values_list("name", flat=True))
+            raise self.StudyOwnerCannotDeleteError(study_names)
+
+        # 사용자 삭제
+        user.delete()

--- a/core/user/views.py
+++ b/core/user/views.py
@@ -5,12 +5,14 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework_simplejwt.tokens import RefreshToken
 from drf_spectacular.utils import extend_schema
 
-from core.models import Study
 from core.utils.cookie import (
     set_secure_cookie,
     delete_auth_cookies,
     ACCESS_TOKEN_LIFETIME,
     REFRESH_TOKEN_LIFETIME,
+    ACCESS_TOKEN_COOKIE,
+    REFRESH_TOKEN_COOKIE,
+    IS_REGISTERED_COOKIE,
 )
 from .serializers import (
     UserInfoSerializer,
@@ -19,6 +21,7 @@ from .serializers import (
     UsernameValidationSerializer,
     BojUsernameValidationSerializer,
 )
+from .services import UserService
 from core.common.serializers import ErrorEnvelopeSerializer
 
 
@@ -47,22 +50,19 @@ class UserMeView(APIView):
     )
     def delete(self, request):
         user = request.user
+        user_service = UserService()
 
-        # 스터디 오너인 경우 탈퇴 불가
-        owned_studies = Study.objects.filter(owner=user)
-        if owned_studies.exists():
-            study_names = list(owned_studies.values_list("name", flat=True))
+        try:
+            user_service.delete_user(user)
+        except UserService.StudyOwnerCannotDeleteError as e:
+            study_list = ", ".join(e.study_names)
             return Response(
                 {
                     "error_code": "STUDY_OWNER_CANNOT_DELETE",
-                    "message": "스터디장인 스터디가 있어 탈퇴할 수 없습니다. 먼저 스터디장을 위임해주세요.",
-                    "studies": study_names,
+                    "message": f"스터디장인 스터디({study_list})가 있어 탈퇴할 수 없습니다. 먼저 스터디장을 위임해주세요.",
                 },
                 status=status.HTTP_400_BAD_REQUEST,
             )
-
-        # 사용자 삭제
-        user.delete()
 
         # 로그아웃 처리 (쿠키 삭제)
         response = Response(status=status.HTTP_204_NO_CONTENT)
@@ -110,19 +110,19 @@ class UserProfileView(APIView):
 
             set_secure_cookie(
                 response,
-                "access_token",
+                ACCESS_TOKEN_COOKIE,
                 access_token,
                 max_age=ACCESS_TOKEN_LIFETIME,
             )
             set_secure_cookie(
                 response,
-                "refresh_token",
+                REFRESH_TOKEN_COOKIE,
                 refresh_token,
                 max_age=REFRESH_TOKEN_LIFETIME,
             )
             set_secure_cookie(
                 response,
-                "is_registered",
+                IS_REGISTERED_COOKIE,
                 "true",
                 max_age=REFRESH_TOKEN_LIFETIME,
             )

--- a/core/user/views.py
+++ b/core/user/views.py
@@ -5,8 +5,10 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework_simplejwt.tokens import RefreshToken
 from drf_spectacular.utils import extend_schema
 
+from core.models import Study
 from core.utils.cookie import (
     set_secure_cookie,
+    delete_auth_cookies,
     ACCESS_TOKEN_LIFETIME,
     REFRESH_TOKEN_LIFETIME,
 )
@@ -22,7 +24,7 @@ from core.common.serializers import ErrorEnvelopeSerializer
 
 @extend_schema(tags=["user"])
 class UserMeView(APIView):
-    """현재 로그인한 사용자 정보 조회 API"""
+    """현재 로그인한 사용자 정보 조회 및 탈퇴 API"""
 
     permission_classes = [IsAuthenticated]
 
@@ -34,6 +36,39 @@ class UserMeView(APIView):
     def get(self, request):
         serializer = UserInfoSerializer(request.user)
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        summary="회원 탈퇴",
+        description="현재 로그인한 사용자의 계정을 삭제합니다. 스터디장인 경우 먼저 스터디장 권한을 위임해야 합니다.",
+        responses={
+            204: None,
+            400: ErrorEnvelopeSerializer,
+        },
+    )
+    def delete(self, request):
+        user = request.user
+
+        # 스터디 오너인 경우 탈퇴 불가
+        owned_studies = Study.objects.filter(owner=user)
+        if owned_studies.exists():
+            study_names = list(owned_studies.values_list("name", flat=True))
+            return Response(
+                {
+                    "error_code": "STUDY_OWNER_CANNOT_DELETE",
+                    "message": "스터디장인 스터디가 있어 탈퇴할 수 없습니다. 먼저 스터디장을 위임해주세요.",
+                    "studies": study_names,
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # 사용자 삭제
+        user.delete()
+
+        # 로그아웃 처리 (쿠키 삭제)
+        response = Response(status=status.HTTP_204_NO_CONTENT)
+        delete_auth_cookies(response)
+
+        return response
 
 
 @extend_schema(tags=["user"])

--- a/core/utils/cookie.py
+++ b/core/utils/cookie.py
@@ -3,6 +3,11 @@ from django.conf import settings
 ACCESS_TOKEN_LIFETIME = settings.SIMPLE_JWT["ACCESS_TOKEN_LIFETIME"]
 REFRESH_TOKEN_LIFETIME = settings.SIMPLE_JWT["REFRESH_TOKEN_LIFETIME"]
 
+# Cookie names
+ACCESS_TOKEN_COOKIE = "access_token"
+REFRESH_TOKEN_COOKIE = "refresh_token"
+IS_REGISTERED_COOKIE = "is_registered"
+
 
 def _get_secure_cookie_kwargs(max_age):
     """
@@ -44,6 +49,6 @@ def delete_auth_cookies(response):
     Args:
         response: Django Response 객체
     """
-    response.delete_cookie("access_token")
-    response.delete_cookie("refresh_token")
-    response.delete_cookie("is_registered")
+    response.delete_cookie(ACCESS_TOKEN_COOKIE)
+    response.delete_cookie(REFRESH_TOKEN_COOKIE)
+    response.delete_cookie(IS_REGISTERED_COOKIE)

--- a/core/utils/cookie.py
+++ b/core/utils/cookie.py
@@ -35,3 +35,15 @@ def set_secure_cookie(response, key, value, max_age):
         max_age: 쿠키 만료 시간 (초 단위)
     """
     response.set_cookie(key, value, **_get_secure_cookie_kwargs(max_age))
+
+
+def delete_auth_cookies(response):
+    """
+    인증 관련 쿠키를 삭제하는 헬퍼 함수
+
+    Args:
+        response: Django Response 객체
+    """
+    response.delete_cookie("access_token")
+    response.delete_cookie("refresh_token")
+    response.delete_cookie("is_registered")


### PR DESCRIPTION
### 🚀 개요 (Overview)

<!---
이 PR의 목적과 배경을 간략하게 설명해주세요.

예시)
[ resolves #1 ]

- 로그인 기능 추가
- 특정 버그 수정
-->

[ resolves #31 ]

- 사용자의 서비스 회원 탈퇴를 위한 API 구현

<br>

### 🔎 변경사항 (Changes)

<!---
이번 PR에서 변경된 주요 내용을 목록으로 작성해주세요.

예시)
- `/pages/login.tsx` 페이지 추가
- 로그인 API 연동을 위한 `/lib/auth.ts` 추가
- 로그인 버튼 컴포넌트 스타일 수정
-->

- `api/user/me` DELETE -> 서비스 회원 탈퇴 API 추가
  - 스터디장으로 되어있는 스터디가 하나라도 있으면 탈퇴가 안되게 함
