### PR TITLE
Feat: UptimeRobot을 위한 간단한 헬스 체크 뷰 추가

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -226,13 +226,3 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
-
-if not DEBUG:
-    SESSION_COOKIE_DOMAIN = ".codte.kr"
-    CSRF_COOKIE_DOMAIN = ".codte.kr"
-
-    # 보안 설정
-    SESSION_COOKIE_SECURE = True
-    CSRF_COOKIE_SECURE = True
-    SESSION_COOKIE_SAMESITE = "None"
-    CSRF_COOKIE_SAMESITE = "None"

--- a/core/auth/views.py
+++ b/core/auth/views.py
@@ -12,6 +12,7 @@ from drf_spectacular.utils import extend_schema, OpenApiExample, OpenApiParamete
 from core.models import User
 from core.utils.cookie import (
     set_secure_cookie,
+    delete_auth_cookies,
     ACCESS_TOKEN_LIFETIME,
     REFRESH_TOKEN_LIFETIME,
     ACCESS_TOKEN_COOKIE,
@@ -162,9 +163,7 @@ class LogoutView(APIView):
 
         response = Response(status=status.HTTP_204_NO_CONTENT)
 
-        response.delete_cookie(ACCESS_TOKEN_COOKIE)
-        response.delete_cookie(REFRESH_TOKEN_COOKIE)
-        response.delete_cookie(IS_REGISTERED_COOKIE)
+        delete_auth_cookies(response)
 
         return response
 

--- a/core/common/urls.py
+++ b/core/common/urls.py
@@ -2,5 +2,5 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path("health", views.health_check, name="health_check"),
+    path("health-check/", views.health_check, name="health_check"),
 ]

--- a/core/common/urls.py
+++ b/core/common/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path("health", views.health_check, name="health_check"),
+]

--- a/core/common/views.py
+++ b/core/common/views.py
@@ -1,0 +1,5 @@
+from django.http import HttpResponse
+
+
+def health_check(request):
+    return HttpResponse("OK")

--- a/core/common/views.py
+++ b/core/common/views.py
@@ -1,7 +1,5 @@
 from django.http import JsonResponse
-from django.views.decorators.http import require_GET
 
 
-@require_GET
 def health_check(request):
     return JsonResponse({"status": "ok"})

--- a/core/common/views.py
+++ b/core/common/views.py
@@ -1,5 +1,7 @@
 from django.http import JsonResponse
+from django.views.decorators.http import require_http_methods
 
 
+@require_http_methods(["GET", "HEAD"])
 def health_check(request):
     return JsonResponse({"status": "ok"})

--- a/core/common/views.py
+++ b/core/common/views.py
@@ -1,5 +1,7 @@
-from django.http import HttpResponse
+from django.http import JsonResponse
+from django.views.decorators.http import require_GET
 
 
+@require_GET
 def health_check(request):
-    return HttpResponse("OK")
+    return JsonResponse({"status": "ok"})

--- a/core/urls.py
+++ b/core/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     path("", include("core.assignments.urls")),
     path("", include("core.note.urls")),
     path("", include("core.problem_solving_status.urls")),
+    path("", include("core.common.urls")),
 ]

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,6 +1,7 @@
 from django.urls import include, path
 
 urlpatterns = [
+    path("", include("core.common.urls")),
     path("", include("core.auth.urls")),
     path("", include("core.user.urls")),
     path("", include("core.study.urls")),
@@ -8,5 +9,4 @@ urlpatterns = [
     path("", include("core.assignments.urls")),
     path("", include("core.note.urls")),
     path("", include("core.problem_solving_status.urls")),
-    path("", include("core.common.urls")),
 ]

--- a/core/utils/cookie.py
+++ b/core/utils/cookie.py
@@ -9,26 +9,31 @@ REFRESH_TOKEN_COOKIE = "refresh_token"
 IS_REGISTERED_COOKIE = "is_registered"
 
 
-def _get_secure_cookie_kwargs(max_age):
+def _get_secure_cookie_kwargs(max_age=None):
     """
     보안 쿠키 설정을 반환하는 헬퍼 함수
-
     Args:
-        max_age: 쿠키 만료 시간 (초 단위)
-
+        max_age: 쿠키 만료 시간 (초 단위). 삭제 시에는 None일 수 있음.
     Returns:
         dict: 쿠키 설정 딕셔너리
     """
-    # 배포 환경에서는 .codte.kr, 디버그 모드에서는 None (자동)
+
+    # 배포: .codte.kr (서브도메인 공유) / 개발: None (localhost)
     domain = ".codte.kr" if not settings.DEBUG else None
+    # 배포: True (HTTPS 필수) / 개발: False (HTTP 허용)
+    secure = True if not settings.DEBUG else False
+    # 배포: Lax / 개발: None
+    samesite = "Lax" if not settings.DEBUG else "None"
 
     kwargs = {
         "httponly": True,
         "domain": domain,
-        "samesite": "None",
-        "secure": True,
-        "max_age": max_age,
+        "samesite": samesite,
+        "secure": secure,
     }
+
+    if max_age is not None:
+        kwargs["max_age"] = max_age
 
     return kwargs
 
@@ -48,14 +53,15 @@ def set_secure_cookie(response, key, value, max_age):
 
 def delete_auth_cookies(response):
     """
-    인증 관련 쿠키를 삭제하는 헬퍼 함수
+    인증 관련 쿠키 삭제하는 헬퍼 함수
+    쿠키를 구울 때와 '똑같은 조건(도메인, 경로 등)'을 줘야 삭제됨
 
     Args:
         response: Django Response 객체
     """
-    # 설정할 때와 동일한 도메인 로직 사용
-    domain = ".codte.kr" if not settings.DEBUG else None
+    cookie_options = _get_secure_cookie_kwargs()
+    cookie_options.pop("max_age", None)
 
-    response.delete_cookie(ACCESS_TOKEN_COOKIE, domain=domain, samesite="None")
-    response.delete_cookie(REFRESH_TOKEN_COOKIE, domain=domain, samesite="None")
-    response.delete_cookie(IS_REGISTERED_COOKIE, domain=domain, samesite="None")
+    response.delete_cookie(ACCESS_TOKEN_COOKIE, **cookie_options)
+    response.delete_cookie(REFRESH_TOKEN_COOKIE, **cookie_options)
+    response.delete_cookie(IS_REGISTERED_COOKIE, **cookie_options)

--- a/core/utils/cookie.py
+++ b/core/utils/cookie.py
@@ -13,7 +13,7 @@ def _get_secure_cookie_kwargs(max_age=None):
     """
     보안 쿠키 설정을 반환하는 헬퍼 함수
     Args:
-        max_age: 쿠키 만료 시간 (초 단위). 삭제 시에는 None일 수 있음.
+        max_age: 쿠키 만료 시간 (초 단위).
     Returns:
         dict: 쿠키 설정 딕셔너리
     """
@@ -22,14 +22,14 @@ def _get_secure_cookie_kwargs(max_age=None):
     domain = ".codte.kr" if not settings.DEBUG else None
     # 배포: True (HTTPS 필수) / 개발: False (HTTP 허용)
     secure = True if not settings.DEBUG else False
-    # 배포: Lax / 개발: None
-    samesite = "Lax" if not settings.DEBUG else "None"
+    # 배포/개발 모두 Lax
+    samesite = "Lax"
 
     kwargs = {
         "httponly": True,
         "domain": domain,
-        "samesite": samesite,
         "secure": secure,
+        "samesite": samesite,
     }
 
     if max_age is not None:


### PR DESCRIPTION
### 🚀 개요 (Overview)

<!---
이 PR의 목적과 배경을 간략하게 설명해주세요.

예시)
[ resolves #1 ]

- 로그인 기능 추가
- 특정 버그 수정
-->

[ resolves #39 ]

- Render 무료 티어는 15분마다 서버가 잠자기 모드가 되는데, 이걸 방지하기 위해 5분마다 찌르기 위해 UptimeRobot을 도입함

<br>

### 🔎 변경사항 (Changes)

<!---
이번 PR에서 변경된 주요 내용을 목록으로 작성해주세요.

예시)
- `/pages/login.tsx` 페이지 추가
- 로그인 API 연동을 위한 `/lib/auth.ts` 추가
- 로그인 버튼 컴포넌트 스타일 수정
-->

- UptimeRobot이 서버를 찌를 수 있도록 간단한 체크 API 구현
- 로그아웃에 쿠키 삭제 함수 적용
- samesite 옵션 Lax 통일
