### PR TITLE
Fix: 쿠키를 삭제할 때 옵션 제거

### DIFF
--- a/core/utils/cookie.py
+++ b/core/utils/cookie.py
@@ -61,6 +61,8 @@ def delete_auth_cookies(response):
     """
     cookie_options = _get_secure_cookie_kwargs()
     cookie_options.pop("max_age", None)
+    cookie_options.pop("httponly", None)
+    cookie_options.pop("secure", None)
 
     response.delete_cookie(ACCESS_TOKEN_COOKIE, **cookie_options)
     response.delete_cookie(REFRESH_TOKEN_COOKIE, **cookie_options)

--- a/core/utils/cookie.py
+++ b/core/utils/cookie.py
@@ -60,9 +60,9 @@ def delete_auth_cookies(response):
         response: Django Response 객체
     """
     cookie_options = _get_secure_cookie_kwargs()
-    cookie_options.pop("max_age", None)
-    cookie_options.pop("httponly", None)
-    cookie_options.pop("secure", None)
+
+    for key in ["max_age", "httponly", "secure"]:
+        cookie_options.pop(key, None)
 
     response.delete_cookie(ACCESS_TOKEN_COOKIE, **cookie_options)
     response.delete_cookie(REFRESH_TOKEN_COOKIE, **cookie_options)


### PR DESCRIPTION
### 🚀 개요 (Overview)

<!---
이 PR의 목적과 배경을 간략하게 설명해주세요.

예시)
[ resolves #1 ]

- 로그인 기능 추가
- 특정 버그 수정
-->

[ resolves #44 ]

- delete cookie에서 지원하지 않는 옵션 제거(httponly, secure)
